### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Matt Wilson <matthew@synesis.com.au>",
 ]
 edition = "2021"
-homepage = "https://github.com/synesissoftware/FastParse.Rust"
+repository = "https://github.com/synesissoftware/FastParse.Rust"
 name = "fastparse"
 readme = "README.md"
 version = "0.0.3"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).